### PR TITLE
Fixing typos in README.md and src/javaDebug.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple debug extension for the Java. It is based on the javac command line debugger.
 
-![Searching in markplace](images/marketplace-search.png)
+![Searching in marketplace](images/marketplace-search.png)
 
 ##Functionality
 First, toggle output:
@@ -34,4 +34,4 @@ Open up VS Code and hit F1 and type ext select "Extensions:Install Extension" an
 
 ##Note
 + Requires [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
-+ *JAVA_HOME* environment variable should be settled and add to *PATH* environment variable aslo needed.
++ *JAVA_HOME* environment variable should be settled and add to *PATH* environment variable also needed.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple debug extension for the Java. It is based on the javac command line deb
 
 ![Searching in marketplace](images/marketplace-search.png)
 
-##Functionality
+## Functionality
 First, toggle output:
 
 > Ctrl + Shift + U
@@ -17,21 +17,21 @@ To run compiled class of selected file.
  
 > Alt + R
 
-##Install
+## Install
 Open up VS Code and hit F1 and type ext select "Extensions:Install Extension" and type "java-debug" hit enter and reload window to enable.
 
 ![Installation](images/intall.gif)
 
-##Fork
+## Fork
 > git clone https://github.com/D-Snake/vscode-java-debug.git
 
-##Feedback
+## Feedback
 + [E-mail Me](mailto:dengbin80@live.com)
 + File a bug in [*GitHub Issues*](https://github.com/D-Snake/vscode-java-debug/issues).
 
 ## License
 >Apache License 2.0
 
-##Note
+## Note
 + Requires [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 + *JAVA_HOME* environment variable should be settled and add to *PATH* environment variable also needed.

--- a/src/javaDebug.ts
+++ b/src/javaDebug.ts
@@ -44,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
                 outputChannel.appendLine(stderr);
                 return;
             }
-            outputChannel.appendLine('Successed!');
+            outputChannel.appendLine('Success!');
         });
     });
 


### PR DESCRIPTION
I just wanted to fix some small spelling errors in the project.
## README.md
- markplace -> marketplace
- aslo -> also
## src/javaDebug.ts
- Successed -> success
